### PR TITLE
Add ability to read non-ortho images

### DIFF
--- a/src/OpenSpaceNet.cpp
+++ b/src/OpenSpaceNet.cpp
@@ -178,12 +178,12 @@ void OpenSpaceNet::initLocalImage()
         sr_ = SpatialReference::WGS84;
     } else {
         OSN_LOG(warning) << "Image has geometric metadata which cannot be converted to WGS84.  "
-                         << "Output will be in native space, and some output formats will fail.";
+                            "Output will be in native space, and some output formats will fail.";
 
         if (args_.bbox) {
             OSN_LOG(warning) << "Supplying the --bbox option implicitly requests a conversion from "
-                             << "WGS84 to pixel space however there is no conversion from WGS84 to "
-                             << "pixel space.";
+                                "WGS84 to pixel space however there is no conversion from WGS84 to "
+                                "pixel space.";
             OSN_LOG(warning) << "Ignoring user-supplied bounding box";
 
             ignoreArgsBbox = true;

--- a/src/OpenSpaceNet.cpp
+++ b/src/OpenSpaceNet.cpp
@@ -282,7 +282,6 @@ void OpenSpaceNet::initFeatureSet()
     VectorOpenMode openMode = args_.append ? APPEND : OVERWRITE;
 
     featureSet_ = make_unique<FeatureSet>(args_.outputPath, args_.outputFormat, openMode);
-    featureSet_->setSpatialReference(sr_);
     layer_ = featureSet_->createLayer(args_.layerName, sr_, args_.geometryType, definitions);
 }
 

--- a/src/OpenSpaceNet.h
+++ b/src/OpenSpaceNet.h
@@ -28,6 +28,7 @@
 #include "OpenSpaceNetArgs.h"
 #include <classification/Model.h>
 #include <classification/Prediction.h>
+#include <geometry/SpatialReference.h>
 #include <imagery/GeoImage.h>
 #include <imagery/MapServiceClient.h>
 #include <imagery/SlidingWindow.h>
@@ -70,6 +71,7 @@ private:
     cv::Rect bbox_;
     std::unique_ptr<deepcore::geometry::Transformation> pixelToLL_;
     deepcore::vector::Layer layer_;
+    deepcore::geometry::SpatialReference sr_;
 };
 
 } } // namespace dg { namespace osn {


### PR DESCRIPTION
This adds the ability for OpenSpaceNet to handle non-orthorectified imagery.  If the image is not ortho-rectified the default OGRSpatialReference is set as the projection of the feature set.

@avitebskiy @rddesmond @geovations